### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,13 +1,14 @@
 name: Greetings
-permissions:
-  issues: write
-  pull-requests: write
 
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request:
     types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   greeting:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,4 +1,7 @@
 name: Greetings
+permissions:
+  issues: write
+  pull-requests: write
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/MStarRobotics/Research/security/code-scanning/1](https://github.com/MStarRobotics/Research/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to only the permissions required by the `actions/first-interaction@v1` action. This action needs to be able to write comments on issues and pull requests, so the minimal permissions required are `issues: write` and `pull-requests: write`. The `permissions` block can be added at the top level of the workflow (applies to all jobs), or at the job level. The best practice is to add it at the top level unless different jobs require different permissions. In this case, since there is only one job, add the following at the top level, after the `name` field and before `on`:

```yaml
permissions:
  issues: write
  pull-requests: write
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
